### PR TITLE
Support OpenSearch Dashboards 1.3.2

### DIFF
--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "kbnPolar",
   "version": "1.0.0",
-  "opensearchDashboardsVersion": "1.2.0",
+  "opensearchDashboardsVersion": "1.3.2",
   "server": false,
   "ui": true,
   "requiredPlugins": [


### PR DESCRIPTION
This PR updates the version of the plugin to be compatible with OpenSearch Dashboards 1.3.2.